### PR TITLE
Remove manual duplicate relation call

### DIFF
--- a/code/GridFieldDetailFormCustom.php
+++ b/code/GridFieldDetailFormCustom.php
@@ -23,11 +23,7 @@ class GridFieldDetailFormCustom_ItemRequest extends GridFieldDetailForm_ItemRequ
 			user_error("Error Duplicating!",
 				E_USER_ERROR);
 		}
-		if ($current_record->many_many()) foreach($current_record->many_many() as $name => $type) {
-			//many_many include belongs_many_many
-			$this->duplicateRelations($current_record, $clone, $name);
-		}
-	
+
 		return Controller::curr()->redirect($this->Link('edit'));
 	}
 


### PR DESCRIPTION
In recent versions of SS relations are created when duplicating a record.
