### PR TITLE
SilverStripe 4 compatibility

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,3 +1,0 @@
-<?php
-
-Config::inst()->update('LeftAndMain','extra_requirements_css', array(basename(dirname(__FILE__)) . '/css/GridFieldCopyButton.css'));

--- a/_config/copybutton.yml
+++ b/_config/copybutton.yml
@@ -1,0 +1,6 @@
+---
+Name: copybutton
+---
+SilverStripe\Admin\LeftAndMain:
+  extra_requirements_css:
+    - "unisolutions/silverstripe-copybutton:css/GridFieldCopyButton.css"

--- a/code/GridField/CopyButton.php
+++ b/code/GridField/CopyButton.php
@@ -1,4 +1,13 @@
 <?php
+
+namespace Unisolutions\GridField;
+
+use SilverStripe\Forms\GridField\GridField_ColumnProvider;
+use SilverStripe\Forms\GridField\GridField_ActionProvider;
+use SilverStripe\Forms\GridField\GridField_FormAction;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\ORM\ValidationException;
+
 /**
  * This component provides a button for copying record.
  * First of all it dublicates record and then opens opens edit form {@link GridFieldDetailForm}.
@@ -8,7 +17,7 @@
  * @author Elvinas Liutkevičius <elvinas@unisolutions.eu>
  * @license BSD http://silverstripe.org/BSD-license
  */
-class GridFieldCopyButton implements GridField_ColumnProvider, GridField_ActionProvider
+class CopyButton implements GridField_ColumnProvider, GridField_ActionProvider
 {
 
     public function augmentColumns($gridField, &$columns)
@@ -57,6 +66,7 @@ class GridFieldCopyButton implements GridField_ColumnProvider, GridField_ActionP
     public function handleAction(GridField $gridField, $actionName, $arguments, $data)
     {
         if ($actionName == 'copyrecord') {
+            /** @var \SilverStripe\ORM\DataObject $item */
             $item = $gridField->getList()->byID($arguments['RecordID']);
             if (!$item) {
                 return;

--- a/code/GridFieldDetailFormCustom.php
+++ b/code/GridFieldDetailFormCustom.php
@@ -1,9 +1,0 @@
-<?php
-
-class GridFieldDetailFormCustom extends GridFieldDetailForm
-{
-    public function __construct()
-    {
-        user_error("The Component GridFieldDetailFormCustom is no longer required for GridFieldCopyButton. Please use GridFieldDetailForm ", E_USER_ERROR);
-    }
-}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "unisolutions/silverstripe-copybutton",
-	"type": "silverstripe-module",
+	"type": "silverstripe-vendormodule",
 	"description": "Adds copy button to the GridField.",
 	"keywords": ["silverstripe", "copy", "button"],
 	"authors": [{
@@ -8,10 +8,21 @@
 		"email": "elvinas@unisolutions.eu"
 	}],
 	"require": {
-		"silverstripe/framework": "3.*"
+		"silverstripe/framework": "^4"
 	},
 	"minimum-stability": "dev",
+	"autoload": {
+		"psr-4": {
+			"Unisolutions\\": "code/"
+		}
+	},
 	"extra": {
-		"installer-name": "copybutton"
+		"branch-alias": {
+			"dev-master": "2.x-dev"
+		},
+		"expose": [
+			"css",
+			"images"
+		]
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
-	"name": "unisolutions/silverstripe-copybutton",
+	"name": "dhensby/silverstripe-copybutton",
 	"type": "silverstripe-module",
+	"license": "BSD-3-Clause",
 	"description": "Adds copy button to the GridField.",
 	"keywords": ["silverstripe", "copy", "button"],
 	"authors": [{
@@ -8,10 +9,13 @@
 		"email": "elvinas@unisolutions.eu"
 	}],
 	"require": {
-		"silverstripe/framework": "3.*"
+		"silverstripe/framework": "^3"
 	},
 	"minimum-stability": "dev",
 	"extra": {
+		"branch-alias": {
+			"1.x-dev": "1.1.x-dev"
+		},
 		"installer-name": "copybutton"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,28 +1,38 @@
 {
-	"name": "unisolutions/silverstripe-copybutton",
-	"type": "silverstripe-vendormodule",
-	"description": "Adds copy button to the GridField.",
-	"keywords": ["silverstripe", "copy", "button"],
-	"authors": [{
-		"name": "Elvinas Liutkevičius",
-		"email": "elvinas@unisolutions.eu"
-	}],
-	"require": {
-		"silverstripe/framework": "^4"
-	},
-	"minimum-stability": "dev",
-	"autoload": {
-		"psr-4": {
-			"Unisolutions\\": "code/"
-		}
-	},
-	"extra": {
-		"branch-alias": {
-			"dev-master": "2.x-dev"
-		},
-		"expose": [
-			"css",
-			"images"
-		]
-	}
+    "name": "dhensby/silverstripe-copybutton",
+    "type": "silverstripe-vendormodule",
+    "description": "Adds copy button to the GridField.",
+    "keywords": [
+        "silverstripe",
+        "copy",
+        "button"
+    ],
+    "authors": [
+        {
+            "name": "Elvinas Liutkevičius",
+            "email": "elvinas@unisolutions.eu"
+        }
+    ],
+    "require": {
+        "silverstripe/framework": "^4"
+    },
+    "autoload": {
+        "psr-4": {
+            "Unisolutions\\": "code/"
+        }
+    },
+    "replace": {
+        "unisolutions/silverstripe-copybutton": "self.version"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev"
+        },
+        "expose": [
+            "css",
+            "images"
+        ]
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
- Add namespace
- Update composer dependencies
- Import correct FQCNs

You'd probably want to branch existing `master` into a `1` so that you can provide support for `1.x` whilst supporting `2.x` in the `master` branch

---

todo:

- [ ] Make CMS grid field icon more like core gridfield icons